### PR TITLE
LGPL-3.0

### DIFF
--- a/package.ini
+++ b/package.ini
@@ -2,7 +2,7 @@
 name=brewnit
 tags=brewing,web
 maintainer=Lucas Bajolet<r4pass@hotmail.com>
-license=LGPL-3
+license=LGPL-3.0
 [upstream]
 git=https://github.com/R4PaSs/brewnit.git
 issues=https://github.com/R4PaSs/brewnit/issues


### PR DESCRIPTION
implicitly fin the link in the calatog http://nitlanguage.org/catalog/p/brewnit.html because https://opensource.org/licenses/LGPL-3.0 works